### PR TITLE
Preserve fuel consumption across loads

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3242,6 +3242,23 @@ void label::serialize( JsonOut &json ) const
     json.end_object();
 }
 
+void vehicle::fuel_consumption_data::deserialize( const JsonObject &data )
+{
+    data.allow_omitted_members();
+    data.read( "fuel_per_sec", fuel_per_sec );
+    data.read( "total_fuel", total_fuel );
+    data.read( "fuel_consumption_dirty", fuel_consumption_dirty );
+}
+
+void vehicle::fuel_consumption_data::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "fuel_per_sec", fuel_per_sec );
+    json.member( "total_fuel", total_fuel );
+    json.member( "fuel_consumption_dirty", fuel_consumption_dirty );
+    json.end_object();
+}
+
 void smart_controller_config::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
@@ -3299,6 +3316,8 @@ void vehicle::deserialize( const JsonObject &data )
     if( !data.read( "last_update_turn", last_update ) ) {
         last_update = calendar::turn;
     }
+
+    data.read( "fuel_used", fuel_used );
 
     units::angle fdir_angle = units::from_degrees( fdir );
     face.init( fdir_angle );
@@ -3483,7 +3502,7 @@ void vehicle::serialize( JsonOut &json ) const
         }
     }
     json.member( "other_tow_point", other_tow_temp_point );
-
+    json.member( "fuel_used", fuel_used );
     json.member( "is_locked", is_locked );
     json.member( "is_alarm_on", is_alarm_on );
     json.member( "camera_on", camera_on );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -746,6 +746,8 @@ class vehicle
             unsigned int total_fuel = 0;
             //"dirty bit" for counting fuel consumption of both generators and engines
             bool fuel_consumption_dirty = false;
+            void deserialize( const JsonObject &data );
+            void serialize( JsonOut &json ) const;
         };
         std::map<itype_id, fuel_consumption_data> fuel_used;
 


### PR DESCRIPTION
This adds serialization for vehicle fuel data, so that the fuel indicators are consistent when quitting & loading.

Not sure if you've encountered any other issues, but the rest looks good to me :+1: